### PR TITLE
Updated nabo.gen.post.ex to slugify Title.

### DIFF
--- a/lib/mix/tasks/nabo.gen.post.ex
+++ b/lib/mix/tasks/nabo.gen.post.ex
@@ -10,21 +10,28 @@ defmodule Mix.Tasks.Nabo.Gen.Post do
 
   ## Example
 
-      mix nabo.gen.post first-post
+      mix nabo.gen.post "Title of Post."
 
   """
 
   @doc false
   def run(args) do
     case OptionParser.parse(args) do
-      {_, [slug], _} ->
+      {_, [title], _} ->
+        slug =
+          title
+          |> String.downcase()
+          |> String.replace(".", "")
+          |> String.replace("'", "")
+          |> String.replace(~r/[^\w-]+/u, "-")
+
         datetime = DateTime.utc_now()
         posts_path = "priv/posts"
         path = Path.relative_to(posts_path, Mix.Project.app_path)
         file = Path.join(path, "#{format_datetime(datetime)}_#{slug}.md")
-        create_file(file, post_template(slug: slug, datetime: datetime))
+        create_file(file, post_template(title: title, slug: slug, datetime: datetime))
       _ ->
-        Mix.raise "expected nabo.gen.post to receive post slug, " <>
+        Mix.raise "expected nabo.gen.post to receive post title, " <>
                   "got: #{inspect(Enum.join(args, " "))}"
     end
   end
@@ -48,7 +55,7 @@ defmodule Mix.Tasks.Nabo.Gen.Post do
 
   embed_template :post, """
   {
-    "title": "",
+    "title": "<%= @title %>",
     "slug": "<%= @slug %>",
     "datetime": "<%= DateTime.to_iso8601(@datetime) %>"
   }


### PR DESCRIPTION
Simple change, allows you to automatically slugify the title on MD creation.

e.g.

```
mix nabo.gen.post "Title of Post."
```